### PR TITLE
Changed fat volume_id parsing to match libblkid format

### DIFF
--- a/dissect/fat/fat.py
+++ b/dissect/fat/fat.py
@@ -84,7 +84,10 @@ class FATFS:
         self.volume_label = bytes(self.bpb_ext.BS_VolLab).strip(b"\x20").decode(encoding)
 
         # volume serial number, hex encoded
-        self.volume_id = f"{self.bpb_ext.BS_VolID:x}"
+        volume_id = f"{self.bpb_ext.BS_VolID:X}"
+        # The uuid of fat filesystems is expected to be in the format '%02X%02X-%02X%02X'
+        # See PR #16
+        self.volume_id = volume_id[:4] + "-" + volume_id[4:]
 
         self.root = RootDirectory(self)
 

--- a/tests/test_fat.py
+++ b/tests/test_fat.py
@@ -9,7 +9,7 @@ def test_fat12(fat12):
     assert fs.fat.bits_per_entry == 12
 
     assert fs.volume_label == volume_label
-    assert fs.volume_id == "e038bb7c"
+    assert fs.volume_id == "E038-BB7C"
     assert fs.cluster_size == 512
 
     verify_fs_content(fs, volume_label)
@@ -23,7 +23,7 @@ def test_fat16(fat16):
     assert fs.fat.bits_per_entry == 16
 
     assert fs.volume_label == volume_label
-    assert fs.volume_id == "88fa453f"
+    assert fs.volume_id == "88FA-453F"
     assert fs.cluster_size == 512
 
     verify_fs_content(fs, volume_label)
@@ -37,7 +37,7 @@ def test_fat32(fat32):
     assert fs.fat.bits_per_entry == 32
 
     assert fs.volume_label == volume_label
-    assert fs.volume_id == "4368dbb7"
+    assert fs.volume_id == "4368-DBB7"
     assert fs.cluster_size == 512
 
     verify_fs_content(fs, volume_label)


### PR DESCRIPTION
This solves #https://github.com/fox-it/dissect.target/pull/273 

This fixes a bug where FAT volumes would not be mounted correctly.
The reason for this lies in the difference between libblkid parsing and dissect parsing.
The difference in format was the UUID `ABCD-1234`
Dissect would parse is as `abcd1234`
And libblkid parses it as `ABCD-1234`

Because of this, fat volumes are not mounted correctly

This PR changes the dissect parsing to match the parsing used in libblkid