### PR TITLE
Move lru_cache definitions to __init__

### DIFF
--- a/dissect/fat/fat.py
+++ b/dissect/fat/fat.py
@@ -149,8 +149,6 @@ class FAT:
     def __init__(self, fh, fattype):
         self.fh = fh
 
-        self.get = lru_cache(4096)(self.get)
-
         if fattype == Fattype.FAT12:
             self.bits_per_entry = 12
         elif fattype == Fattype.FAT16:
@@ -161,6 +159,8 @@ class FAT:
             raise TypeError("Unsupported FAT type")
 
         self.entry_count = int(self.fh.size // (self.bits_per_entry / 8))
+
+        self.get = lru_cache(4096)(self.get)
 
     def get(self, cluster):
         if cluster >= self.entry_count:


### PR DESCRIPTION
Using the lru_cache decorators on class methods, the ones that have a reference to `self`,
will also cache self. So we move it to the __init__ of the class
    
(DIS-2913)