### PR TITLE
Fix ExFAT parsing with clusters larger than one sector

### DIFF
--- a/dissect/fat/c_exfat.py
+++ b/dissect/fat/c_exfat.py
@@ -79,7 +79,7 @@ typedef struct STREAM_DIRECTORY_ENTRY {
     uint64 valid_data_length;          // 0x08 allocated size of data in bytes only counts for files and is used for
                                        // pre-allocation zero if directory
     uint8 reserved_2[4];               // 0x10 no clue always zero
-    uint32 location;                   // 0x15 starting cluster of data
+    uint32 location;                   // 0x14 starting cluster of data
     uint64 data_length;                // 0x18 actual size of data if directory always multiples of sector size
 };
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,13 @@ def exfat_simple():
 
 
 @pytest.fixture
+def exfat_4m():
+    name = "data/exfat4m.bin"
+    with open(absolute_path(name), "rb") as f:
+        yield f
+
+
+@pytest.fixture
 def fat12():
     name = "data/fat12.bin"
     with open(absolute_path(name), "rb") as f:

--- a/tests/data/exfat4m.bin
+++ b/tests/data/exfat4m.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21350fa8b43f67b1d726dec1cdbd24505bffc8462db00d20017d5dd195557629
+size 4194304

--- a/tests/test_exfat.py
+++ b/tests/test_exfat.py
@@ -39,3 +39,36 @@ def test_exfat(exfat_simple):
     assert sysvol.metadata.attributes.directory == 1
     assert sysvol.stream.flags.not_fragmented == 1
     assert sysvol.stream.data_length == 512
+
+
+def test_exfat_4m(exfat_4m):
+    e = exfat.ExFAT(exfat_4m)
+
+    assert e.volume_label == ""
+    assert e.cluster_count == 512
+    assert e.sector_size == 512
+    assert e.cluster_size == 4096
+    assert e.fat_sector == 2048
+    assert e.root_dir_cluster == 5
+    assert e.root_dir_sector == 4120
+    assert e.runlist(e.root_dir_cluster) == [(e.root_dir_sector, 8)]
+
+    files = e.files
+    assert sorted(files.keys()) == ["/"]
+
+    root = files["/"][0]
+    assert root.metadata.attributes.directory == 1
+    assert root.stream.flags.not_fragmented == 0
+    assert root.stream.data_length == 4096
+
+    empty_file = files["/"][1]["file.txt"][0]
+    assert empty_file.metadata.attributes.directory == 0
+    assert empty_file.stream.flags.not_fragmented == 0
+    assert empty_file.stream.data_length == 0
+
+    subdir = files["/"][1]["subdir"][0]
+    assert subdir.metadata.attributes.directory == 1
+    assert subdir.stream.flags.not_fragmented == 1
+    assert subdir.stream.data_length == 4096
+
+    assert sorted(files["/"][1]["subdir"][1].keys()) == ["sub.txt"]


### PR DESCRIPTION
The existing `exfat.bin` testcase is configured with a sector size equal to the cluster size. When that is not the case, parsing the root directory and subdirectory entries fails with an EOFError. Since directory entries are sector-aligned, reduce the block size to match. Fix some mistakes and clarify the documentation while at it.

Fixes a crash reproduced with with exfatprogs version 1.2.6:

    truncate -s 4M exfat4m.bin; mkfs.exfat exfat4m.bin
    python3 -c 'from dissect.fat import ExFAT; fs = ExFAT(open("exfat4m.bin", "rb")); print(fs.files["/"][1].keys())'

This check for a file and subdirectory also passes now:

    # mount exfat4m.bin /mnt
    # mkdir /mnt/subdir
    # touch /mnt/file.txt /mnt/subdir/sub.txt
    # umount /mnt
    $ python3 -c 'from dissect.fat import ExFAT; fs = ExFAT(open("exfat4m.bin", "rb")); print(fs.files["/"][1]["subdir"][1].keys())'
    odict_keys(['sub.txt'])
    $ python3 -c 'from dissect.fat import ExFAT; fs = ExFAT(open("exfat4m.bin", "rb")); print(fs.files["/"][1].keys())'
    odict_keys(['subdir', 'file.txt'])

This test file has been included in the test suite.